### PR TITLE
Use the file names resolved by TypeScript for support of include and exclude globs

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -122,4 +122,4 @@ if (configParseResult.errors.length > 0) {
   return
 }
 
-compile(loadedConfigFile.files, configParseResult.options, null, null)
+compile(configParseResult.fileNames, configParseResult.options, null, null)

--- a/src/transformersUtils.js
+++ b/src/transformersUtils.js
@@ -135,7 +135,7 @@ module.exports.compile = function (configFilePath, configFileName, loadedConfigF
 
       const compilerOptions = configParseResult.options
 
-      compile(loadedConfigFile.files, compilerOptions, before, after)
+      compile(configParseResult.fileNames, compilerOptions, before, after)
     }).catch(error => {
       ts.sys.write(error.message)
       ts.sys.exit(ts.ExitStatus.DiagnosticsPresent_OutputsSkipped)

--- a/test/smoke/package.json
+++ b/test/smoke/package.json
@@ -7,6 +7,6 @@
   },
   "scripts": {
     "setup": "npm link ../..",
-    "test": "tstc"
+    "test": "tstc && tstc -p tsconfig-include-exclude.json"
   }
 }

--- a/test/smoke/tsconfig-include-exclude.json
+++ b/test/smoke/tsconfig-include-exclude.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "outDir": "../out",
+    "target": "es2017",
+    "moduleResolution": "node",
+    "module": "smoke-module",
+    "allowJs": true
+  },
+  "include": [
+    "**/*.js"
+  ],
+  "exclude": [
+    "*/**/*.js"
+  ],
+  "transformers": "./transformers.json"
+}


### PR DESCRIPTION
Currently only the `files` parameter in tsconfig.json is supported; this pull request uses `fileNames` from the parsed config rather than `files` from the config file. This change allows files to be resolved for configs that use `include` and `exclude` and from configs that inherit a file list by extending another config or that omit a specification of the files entirely. A test config was added with `include` and `exclude` specified in lieu of explicit `files`.

Without these changes, `tstc` produces no output given a project that does not explicitly specify the `files` to process.