### PR TITLE
Allow before and after transformers to access the TypeScript program

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,14 @@ Transformers in the tsconfig file example
 #### Example Transformer
 
 ```js
-module.exports = function (transformerConfig) {
+module.exports = function (transformerConfig, program) {
 
   console.log("config", transformerConfig)
 
   // this is the function given to the typescript compiler
   return function (context) {
     const ts = require('typescript')
+    const typeChecker = program.getTypeChecker();
 
     function visit(node) {
       console.log("visited")

--- a/src/compile.js
+++ b/src/compile.js
@@ -14,12 +14,12 @@ module.exports = function (fileNames, compilerOptions, beforeTransformers, after
 
   if (beforeTransformers)
     before = beforeTransformers.map(
-      transformer => transformer.handler(transformer.config)
+      transformer => transformer.handler(transformer.config, program)
     )
 
   if (afterTransformers)
     after = afterTransformers.map(
-      transformer => transformer.handler(transformer.config)
+      transformer => transformer.handler(transformer.config, program)
     )
 
   const transformers = { before, after }

--- a/test/smoke/transformers/smoke/index.js
+++ b/test/smoke/transformers/smoke/index.js
@@ -1,9 +1,10 @@
-module.exports = function (transformerConfig) {
+module.exports = function (transformerConfig, program) {
 
   console.log("config", transformerConfig)
 
   return function (context) {
     const ts = require('typescript')
+    const typeChecker = program.getTypeChecker();
 
     function visit(node) {
       console.log("visited")


### PR DESCRIPTION
I was trying to set up ts-transformer-cli with ts-transformer-keys but noticed that the latter required access to the TypeScript Program to inspect type information. This pull request adds the program as a second argument to before and after transformers. I am not sure whether this is the best way to approach this problem or if there is any similar functionality available to the module transformer.