### PR TITLE
Use forward slashes in .npmignore to avoid ignoring files during install

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,6 @@
 !README.md
 !LICENSE.md
 !CHANGELOG.md
-!src\**\*
-!bin\**\*
+!src/**/*
+!bin/**/*
 !package.json


### PR DESCRIPTION
I was unable to install the project from GitHub with npm because the .npmignore file was filtering out the `src` and `bin` directories. npm errored out upon attempting to link the binary since it did not exist. Updating the globs to use forward slashes resolved the issue.