### PR TITLE
Require typescript ^2.3.3 to avoid version conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "jshint": "2.9.5"
   },
   "dependencies": {
-    "typescript": "2.7.2"
+    "typescript": "^2.3.3"
   },
   "bin": {
     "tstc": "./bin/tstc"


### PR DESCRIPTION
The latest commit here to require exactly TypeScript 2.7.2 will usually result in this module getting its own copy of TypeScript separate from whichever alternate version is in use by the project. In my case for whatever reason this causes a transformer to not produce the correct output. Since the ts-transformer-cli code does not seem to require 2.7.2 I think it is best to revert that change to a less specific version range.